### PR TITLE
Get output and long output from service/host

### DIFF
--- a/library/Jira/Web/Form/NewIssueForm.php
+++ b/library/Jira/Web/Form/NewIssueForm.php
@@ -105,7 +105,10 @@ class NewIssueForm extends QuickForm
     {
         $object = $this->object;
         if ($object->getType() === 'service') {
-            $description = $object->service_output;
+            $description = sprintf("%s\n%s",
+                $object->service_output,
+                str_replace('\n',"\n", $object->service_long_output)
+            );
             $summary = sprintf(
                 '%s on %s is %s',
                 $object->service_description,
@@ -113,7 +116,10 @@ class NewIssueForm extends QuickForm
                 $this->getStateName()
             );
         } else {
-            $description = $object->host_output;
+            $description = sprintf("%s\n%s",
+                $object->host_output,
+                str_replace('\n',"\n",$object->host_long_output)
+            );
             $summary = sprintf(
                 '%s is %s',
                 $object->host_name,


### PR DESCRIPTION
Icinga splits the first line and later lines into two different fields.
This concatenates them back together for the summary.

[service/host]_long_output also includes a range of \n which don't get
interpretted, so using str_replace to force them into newlines when
submitted to jira.