### PR TITLE
Template can not pass complex custom fields

### DIFF
--- a/library/Jira/IssueTemplate.php
+++ b/library/Jira/IssueTemplate.php
@@ -48,11 +48,18 @@ class IssueTemplate
         } else {
             $remaining = substr($key, $dot + 1);
             $key = substr($key, 0, $dot);
-            if (! array_key_exists($key, $fields)) {
-                $fields[$key] = [];
-            }
 
-            $this->addToFields($fields[$key], $remaining, $value);
+            if(strpos($remaining, '.') !== false) {
+                $remaining = substr($remaining, 1);
+                $subkey[$remaining] = $value;
+                $fields[$key][] = $subkey;
+            } else {
+                if (! array_key_exists($key, $fields)) {
+                    $fields[$key] = [];
+                }
+
+                $this->addToFields($fields[$key], $remaining, $value);
+            }
         }
     }
 


### PR DESCRIPTION
for Issue #15 

I have extended the `template.ini` File so that if we type `key..subkey = value` the subkey = value pair will be wrapped in an array agian.

```[so]
Account = "${account}"
customfield_10502..key = "${customer}"
customfield_10802..key = "${hostkey}"
```
using this syntax in the config file allowed me to modify the code as few as possible