### PR TITLE
module.info: name the module itself via Module:

### DIFF
--- a/module.info
+++ b/module.info
@@ -1,3 +1,4 @@
+Module: jira
 Name: JIRA
 Version: 1.0.1
 Depends: monitoring (>=2.6.0), ipl (>=0.3.0), incubator (>=0.5.0)


### PR DESCRIPTION
[You clearly told me](https://community.icinga.com/t/new-icinga-web-module-repo-naming-scheme/3775/2?u=al2klimov) that my current auto-discovery's base won't survive. But the only other option is broken – here's the fix.