### PR TITLE
  Added Transfer-Encoding: chunked header

### DIFF
--- a/library/Jira/RestApi.php
+++ b/library/Jira/RestApi.php
@@ -345,6 +345,8 @@ class RestApi
             $body = \json_encode($body);
         }
         $headers[] = 'Content-Type: application/json';
+        $headers[] = 'Transfer-Encoding: chunked';
+
 
         $curl = $this->curl();
         $opts = array(

--- a/library/Jira/RestApi.php
+++ b/library/Jira/RestApi.php
@@ -343,10 +343,11 @@ class RestApi
 
         if ($body !== null) {
             $body = \json_encode($body);
+            $headers[] = 'Content-Length: ' . strlen($body);
         }
         $headers[] = 'Content-Type: application/json';
-        $headers[] = 'Transfer-Encoding: chunked';
 
+       
 
         $curl = $this->curl();
         $opts = array(

--- a/library/Jira/RestApi.php
+++ b/library/Jira/RestApi.php
@@ -346,9 +346,7 @@ class RestApi
             $headers[] = 'Content-Length: ' . strlen($body);
         }
         $headers[] = 'Content-Type: application/json';
-
-       
-
+   
         $curl = $this->curl();
         $opts = array(
             CURLOPT_URL            => $this->url($url),

--- a/library/Jira/RestApi.php
+++ b/library/Jira/RestApi.php
@@ -346,7 +346,7 @@ class RestApi
             $headers[] = 'Content-Length: ' . strlen($body);
         }
         $headers[] = 'Content-Type: application/json';
-   
+
         $curl = $this->curl();
         $opts = array(
             CURLOPT_URL            => $this->url($url),


### PR DESCRIPTION
    Jira instances behind a reverse proxy would require
    Content-Lenght value or Transfer-Encoding set to chunked.
    
    Some more info might be found here: https://bugs.php.net/bug.php?id=79013&edit=1 despite
    the issue mentioned here is not exactly the same (thy're referring to HTTP/2.