### PR TITLE
Fix creation of tickets for onprem Jira with version above version v9.x.x

### DIFF
--- a/application/controllers/ConfigurationController.php
+++ b/application/controllers/ConfigurationController.php
@@ -60,7 +60,8 @@ class ConfigurationController extends Controller
     public function directorAction()
     {
         $this->assertPermission('director/admin');
-
+        $this->mergeTabs($this->Module()->getConfigTabs()->activate('director'));
+        
         $this->addTitle('Director Config Preview')->activateTab();
         if ($this->params->get('action') === 'sync') {
             $this->runFailSafe('sync');
@@ -153,10 +154,7 @@ class ConfigurationController extends Controller
         if ($name === null) {
             $name = $this->getRequest()->getActionName();
         }
-        $this->getTabs()->add('director', [
-            'label' => $this->translate('Director Config'),
-            'url' => 'jira/configuration/director',
-        ])->add('inspect', [
+        $this->getTabs()->add('inspect', [
             'label' => $this->translate('Inspect'),
             'url' => 'jira/configuration/inspect',
         ])->activate($name);

--- a/application/forms/Config/ConfigForm.php
+++ b/application/forms/Config/ConfigForm.php
@@ -1,0 +1,57 @@
+<?php
+
+// Icinga Web JIRA Integration | (c) 2023 Icinga GmbH | GPLv2
+
+namespace Icinga\Module\Jira\Forms\Config;
+
+use Icinga\Application\Config;
+use Icinga\Module\Jira\RestApi;
+use Icinga\Web\Notification;
+use ipl\Validator\CallbackValidator;
+use ipl\Web\Compat\CompatForm;
+
+class ConfigForm extends CompatForm
+{
+    protected function assemble()
+    {
+        $this->addElement('select', 'type', [
+            'class'         => 'autosubmit',
+            'label'         => t('Deployment Type'),
+            'description'   => t('Select deployment type'),
+            'required'      => true,
+            'options'       => [
+                'cloud'  => t('Cloud'),
+                'server' => t('Server')
+            ],
+            'validators'    => [
+                'Callback' => function ($value, $validator) {
+                    /** @var CallbackValidator $validator */
+                    $serverInfo = RestApi::fromConfig()->get('serverInfo')->getResult();
+
+                    if ($value !== strtolower($serverInfo->deploymentType)) {
+                        $validator->addMessage(
+                            t('Jira Software seems to be deployed differently.')
+                        );
+                        return false;
+                    }
+
+                    return true;
+                }
+            ]
+        ]);
+
+        if ($this->getValue('type') === 'cloud') {
+            $this->addElement('checkbox', 'legacy', [
+                'label'             => t('Legacy compatibility'),
+                'description'       => t('Enable legacy compatibility if unable to create jira issues'),
+                'class'             => 'autosubmit',
+                'checkedValue'      => '1',
+                'uncheckedValue'    => '0'
+            ]);
+        }
+
+        $this->addElement('submit', 'btn_submit', [
+            'label' => t('Save Changes')
+        ]);
+    }
+}

--- a/application/forms/Config/ConfigForm.php
+++ b/application/forms/Config/ConfigForm.php
@@ -26,12 +26,10 @@ class ConfigForm extends CompatForm
             'validators'    => [
                 'Callback' => function ($value, $validator) {
                     /** @var CallbackValidator $validator */
-                    $serverInfo = RestApi::fromConfig()->get('serverInfo')->getResult();
+                    $serverInfo = RestApi::fromConfig()->getServerInfo();
 
                     if ($value !== strtolower($serverInfo->deploymentType)) {
-                        $validator->addMessage(
-                            t('Jira Software seems to be deployed differently.')
-                        );
+                        $validator->addMessage(t('Jira Software seems to be deployed differently.'));
                         return false;
                     }
 

--- a/configuration.php
+++ b/configuration.php
@@ -13,3 +13,11 @@ if ($this->app->getModuleManager()->hasEnabled('director')) {
         ->setPermission('director/admin');
 }
 $this->providePermission('jira/issue/create', $this->translate('Allow to manually create issues'));
+
+$this->provideConfigTab(
+    'deployment',
+    [
+        'label' => t('Configuration'),
+        'url'   => 'configuration'
+    ]
+);

--- a/configuration.php
+++ b/configuration.php
@@ -6,12 +6,7 @@ $section = $this->menuSection(N_('Jira'))
     ->setPriority(63)
     ->setIcon('tasks');
 $section->add(N_('Issues'))->setUrl('jira/issues')->setPriority(10);
-if ($this->app->getModuleManager()->hasEnabled('director')) {
-    $section->add(N_('Configuration'))
-        ->setUrl('jira/configuration/director')
-        ->setPriority(20)
-        ->setPermission('director/admin');
-}
+
 $this->providePermission('jira/issue/create', $this->translate('Allow to manually create issues'));
 
 $this->provideConfigTab(
@@ -21,3 +16,14 @@ $this->provideConfigTab(
         'url'   => 'configuration'
     ]
 );
+
+if ($this->app->getModuleManager()->hasEnabled('director')) {
+    $this->provideConfigTab(
+        'director',
+        [
+            'label' => t('Director Config'),
+            'title' => t('Director Config Preview'),
+            'url'   => 'configuration/director'
+        ]
+    );
+}

--- a/library/Jira/RestApi.php
+++ b/library/Jira/RestApi.php
@@ -25,6 +25,9 @@ class RestApi
     
     protected $apiVersion = '2';
 
+    /** @var object Server info of Jira Software */
+    protected $serverInfo;
+
     protected $enumCustomFields;
 
     public function __construct($baseUrl, $username, $password)
@@ -33,6 +36,7 @@ class RestApi
         $this->password = $password;
         $this->baseUrlForLink = $baseUrl;
         $this->baseUrl = \rtrim($baseUrl, '/') . '/rest';
+        $this->serverInfo = $this->get('serverInfo')->getResult();
     }
 
     /**
@@ -60,6 +64,26 @@ class RestApi
         $api = new static($url, $user, $pass);
 
         return $api;
+    }
+
+    /**
+     * Get Jira Software Version
+     *
+     * @return string
+     */
+    public function getJiraVersion(): string
+    {
+        return $this->serverInfo->version;
+    }
+
+    /**
+     * Check if Jira Software is deployed on server (on-prem)
+     *
+     * @return bool
+     */
+    public function isServer(): bool
+    {
+        return strtolower($this->serverInfo->deploymentType) === 'server';
     }
 
     /**
@@ -476,5 +500,15 @@ class RestApi
         }
 
         return $this->curl;
+    }
+
+    /**
+     * Get server info of Jira Software
+     *
+     * @return object
+     */
+    public function getServerInfo(): object
+    {
+        return $this->serverInfo;
     }
 }

--- a/module.info
+++ b/module.info
@@ -1,6 +1,6 @@
 Name: JIRA
 Version: 1.2.2
-Depends: monitoring (>=2.9.0), icingadb, ipl (>=0.8.0)
+Depends: monitoring (>=2.9.0), icingadb, ipl (>=0.11.0)
 Description: JIRA integration
  This module allows to send notifications to JIRA and integrates nicely into
  the Icinga Web 2 frontend. It hooks into Icinga Director and into the monitoring


### PR DESCRIPTION
Since Jira v9.x.x  Get create issue meta (`GET /rest/api/2/issue/createmeta`) api call is deprecated and dropped.

This is replaced with:
    Get create issue meta project issue types -> `(GET /rest/issue/createmeta/{projectIdOrKey}/issuetypes)` and
    Get create issue meta fields -> `GET /rest/issue/createmeta/{projectIdOrKey}/issuetypes/{issueTypeId}`

In this PR, the changes are made to accommodate this update.

#87 and #85