### PR TITLE
use other names for "icingaKey" and "icingaStatus"

### DIFF
--- a/application/clicommands/SendCommand.php
+++ b/application/clicommands/SendCommand.php
@@ -5,6 +5,7 @@ namespace Icinga\Module\Jira\Clicommands;
 use Exception;
 use Icinga\Application\Icinga;
 use Icinga\Application\Logger;
+use Icinga\Application\Config;
 use Icinga\Module\Jira\IcingaCommandPipe;
 use Icinga\Module\Jira\Cli\Command;
 use Icinga\Module\Jira\IcingadbBackend;
@@ -67,6 +68,7 @@ class SendCommand extends Command
 
         $jira = $this->jira();
         $issue = $jira->eventuallyGetLatestOpenIssueFor($host, $service);
+        $config = Config::module('jira');
         $mm = $this->app->getModuleManager();
         if ($p->shift('icingadb') || ! $mm->hasEnabled('monitoring')) {
             if (! $mm->hasEnabled('icingadb')) {
@@ -114,11 +116,12 @@ class SendCommand extends Command
             $ackMessage = "JIRA issue $key has been created";
         } else {
             $key = $issue->key;
-            $currentStatus = isset($issue->fields->icingaStatus) ? $issue->fields->icingaStatus : null;
+            $icingaStatus = $config->get('ui', 'field_icingaStatus', 'icingaStatus');
+            $currentStatus = isset($issue->fields->$icingaStatus) ? $issue->fields->$icingaStatus : null;
             $ackMessage = "Existing JIRA issue $key has been found";
             if ($currentStatus !== $status) {
                 $update = new IssueUpdate($jira, $key);
-                $update->setCustomField('icingaStatus', $status);
+                $update->setCustomField($icingaStatus, $status);
                 $update->addComment("Status changed to $status\n" . $description);
                 $jira->updateIssue($update);
             }

--- a/doc/03-Configuration.md
+++ b/doc/03-Configuration.md
@@ -40,6 +40,10 @@ password = "password"
 ; default_project = "SO"
 ; default_issuetype = "Event"
 
+[jira_key_fields]
+; field_icingaStatus = "icingaStatus"
+; field_icingaKey = "icingaKey"
+
 [icingaweb]
 url = "https://icinga.example.com/icingaweb2"
 ```

--- a/library/Jira/IssueTemplate.php
+++ b/library/Jira/IssueTemplate.php
@@ -127,6 +127,9 @@ class IssueTemplate
 
     protected function getDefaultFields()
     {
+        $config = Config::module('jira');
+        $Key = $config->get('jira_key_fields', 'field_icingaKey', 'icingaKey');
+        $Status = $config->get('jira_key_fields', 'field_icingaStatus', 'icingaStatus');
         return [
             'project.key'    => '${project}',
             'issuetype.name' => '${issuetype}',
@@ -134,6 +137,8 @@ class IssueTemplate
             'description'    => '${description}',
             'icingaKey'      => '${icingaKey}',
             'icingaStatus'   => '${state}',
+            $Key             => '${icingaKey}',
+            $Status          => '${state}',
         ];
     }
 }

--- a/library/Jira/Web/Table/IssueDetails.php
+++ b/library/Jira/Web/Table/IssueDetails.php
@@ -2,6 +2,7 @@
 
 namespace Icinga\Module\Jira\Web\Table;
 
+use Icinga\Application\Config;
 use Icinga\Module\Jira\Web\RenderingHelper;
 use ipl\Html\Html;
 use ipl\Html\HtmlString;
@@ -30,11 +31,13 @@ class IssueDetails extends Table
         $helper = $this->helper;
         $issue = $this->issue;
         $key = $issue->key;
+        $config = Config::module('jira');
 
         $fields = $issue->fields;
         $projectKey = $fields->project->key;
+        $keyField = $config->get('jira_key_fields', 'field_icingaKey', 'icingaKey');
 
-        $icingaKey = preg_replace('/^BEGIN(.+)END$/', '$1', $fields->icingaKey);
+        $icingaKey = preg_replace('/^BEGIN(.+)END$/', '$1', $fields->$keyField);
         $parts = explode('!', $icingaKey);
         $host = array_shift($parts);
         if (empty($parts)) {


### PR DESCRIPTION
Hi.
our JIRA team doesn't allow us to define "special" variables called "IcingaKey" and "IcingaStatus". Instead we have to "re-use" other fields that are already defined (for other departments).

I changed the code so these fields are now configure options in config.ini, maybe you will find that useful :-)

(this is essentially PR #58, I just had some unverified usernames in the commits before)