### PR TITLE
Fix the field input elements created for template in case of system fields in `NewIssueForm`

### DIFF
--- a/library/Jira/Web/Form/NewIssueForm.php
+++ b/library/Jira/Web/Form/NewIssueForm.php
@@ -159,7 +159,7 @@ class NewIssueForm extends CompatForm
                     $elementName = $key;
                     $label = $jiraCustomFields[$key];
                 } else {
-                    $elementName = array_search($key, $jiraCustomFields);
+                    $elementName = array_search($key, $jiraCustomFields) ?: $key;
                 }
 
                 $this->addElement(


### PR DESCRIPTION
If the system fields are present in templates the elementName for the input element is assigned to be false. This causes an error while adding this element. This has been fixed here.

fixes #107 