### PR TITLE
Use default branch as `main`

### DIFF
--- a/.github/workflows/L10n-update.yml
+++ b/.github/workflows/L10n-update.yml
@@ -3,7 +3,7 @@ name: L10n Update
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   trigger-update:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -3,11 +3,11 @@ name: PHP Tests
 on:
   push:
     branches:
-      - master
+      - main
       - release/*
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   lint:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Icinga Web Jira Integration
 
 [![PHP Support](https://img.shields.io/badge/php-%3E%3D%207.2-777BB4?logo=PHP)](https://php.net/)
-![Build Status](https://github.com/icinga/icingaweb2-module-jira/workflows/PHP%20Tests/badge.svg?branch=master)
+![Build Status](https://github.com/icinga/icingaweb2-module-jira/workflows/PHP%20Tests/badge.svg?branch=main)
 [![Github Tag](https://img.shields.io/github/tag/Icinga/icingaweb2-module-jira.svg)](https://github.com/Icinga/icingaweb2-module-jira)
 
 ![Icinga Logo](https://icinga.com/wp-content/uploads/2014/06/icinga_logo.png)


### PR DESCRIPTION
The default branch has been switched to `main` from `master`. Hence, use `main` where required.