### PR TITLE
Jira API Communication Add Proxy

### DIFF
--- a/application/forms/Config/ConfigForm.php
+++ b/application/forms/Config/ConfigForm.php
@@ -58,6 +58,17 @@ class ConfigForm extends CompatForm
                 'label'       => $this->translate('Scheme'),
                 'description' => $this->translate('Protocol used by Jira (http / https)'),
             ]
+        )->addElement(
+            'text',
+            'proxy',
+            [
+                'label'    => $this->translate('Proxy Server'),
+                'description' => $this->translate(
+                    'Proxy Server used to connect to Jira if needed, '
+                    . 'format <hostname or IP>:<port>'
+                ),
+                'required' => false,
+            ]
         );
 
         $this->addElement(

--- a/library/Jira/RestApi.php
+++ b/library/Jira/RestApi.php
@@ -31,12 +31,15 @@ class RestApi
 
     protected $enumCustomFields;
 
-    public function __construct($baseUrl, $username, $password)
+    protected $proxy;
+
+    public function __construct($baseUrl, $username, $password, ?string $proxy)
     {
         $this->username = $username;
         $this->password = $password;
         $this->baseUrlForLink = $baseUrl;
         $this->baseUrl = \rtrim($baseUrl, '/') . '/rest';
+        $this->proxy = $proxy;
         $this->serverInfo = $this->get('serverInfo')->getResult();
     }
 
@@ -61,8 +64,9 @@ class RestApi
 
         $user = $config->get('api', 'username');
         $pass = $config->get('api', 'password');
+        $proxy = $config->get('api', 'proxy');
 
-        $api = new static($url, $user, $pass);
+        $api = new static($url, $user, $pass, $proxy);
 
         return $api;
     }
@@ -449,6 +453,10 @@ class RestApi
         $opts[CURLOPT_HTTPHEADER] = $headers;
 
         $curl = $this->curl();
+
+        if ($this->proxy) {
+            $opts[CURLOPT_PROXY] = $this->proxy;
+        }
 
         curl_setopt_array($curl, $opts);
         // TODO: request headers, validate status code


### PR DESCRIPTION
We have recently migrated to Jira Cloud environment, for the Icinga Integration to work, we needed to connect to the Jira Cloud, through a Proxy Server, because direct Access was restricted.
I have implemented a small change, to configure a Proxy Server, in the Icinga Jira API Configuration

fix feture request: #135 