### PR TITLE
Introduce IcingaKeyPrefix #153, enclose  in single quotes #154

### DIFF
--- a/application/forms/Config/ConfigForm.php
+++ b/application/forms/Config/ConfigForm.php
@@ -210,6 +210,17 @@ class ConfigForm extends CompatForm
                     }
                 ]
             ]
+        )->addElement(
+            'text',
+            'icingaKeyPrefix',
+            [
+                'label'       => 'icingaKeyPrefix',
+                'description' => $this->translate(
+                    'Custom name that is prefixed to the icingaKey, If you plan to have multiple individual '
+                    . 'icinga instances write to the same jira project you should set a meaningful name her like cluster1'
+                ),
+                'required'    => false,
+            ]
         );
 
         // Fieldset for UI

--- a/doc/03-Configuration.md
+++ b/doc/03-Configuration.md
@@ -89,6 +89,11 @@ following JQL construct:
 A little bit weird, but it should work fine. And as this field is usually not
 shown anywhere, it shouldn't disturb.
 
+If you also set the icingaKeyPrefix to something that is not `''` like `cluster1` your JQL construct
+will look like this:
+
+    icingaKey ~ "\"BEGIN_cluster1_example.com!Disk SpaceEND\""
+
 ## Fill Jira Custom Fields
 
 For your customized workflows you might need this module to ship additional

--- a/library/Jira/RestApi.php
+++ b/library/Jira/RestApi.php
@@ -207,17 +207,22 @@ class RestApi
 
         $config = Config::module('jira');
         $keyField = $config->get('key_fields', 'icingaKey', 'icingaKey');
+        $prefix = $config->get('key_fields', 'icingaKeyPrefix', '');
 
         if ($host === null) {
-            $query .= ' AND ' . $keyField . ' ~ "BEGIN*"';
+            $pattern = 'BEGIN*';
+            if ($prefix !== '') {
+                $pattern = 'BEGIN_' . $prefix . '_*';
+            }
         } else {
-            $icingaKey = static::makeIcingaKey($host, $service);
-
+            $pattern = static::makeIcingaKey($host, $service);
             // There is no exact field matcher out of the box on Jira, this is
-            // an ugly work-around. We search for "BEGINhostnameEND" or
-            // "BEGINhostname!serviceEND"
-            $query .= \sprintf(' AND ' . $keyField . ' ~ "\"%s\""', $icingaKey);
+            // an ugly work-around. We search for "BEGINhostnameEND" or "BEGIN_YOURPREFIX_hostname"
+            // "BEGINhostname!serviceEND" or "BEGIN_YOURPREFIX_hostname!serviceEND"
+
         }
+
+        $query .= \sprintf(" AND '$keyField'" . ' ~ "\"%s\""', $pattern);
 
         $query .= ' ORDER BY created DESC';
 
@@ -226,7 +231,12 @@ class RestApi
 
     public static function makeIcingaKey($host, $service = null)
     {
+        $prefix = Config::module('jira')->get('key_fields', 'icingaKeyPrefix', '');
         $icingaKey = "BEGIN$host";
+        if ($prefix !== '') {
+            $icingaKey = "BEGIN_{$prefix}_{$host}";
+        }
+
         if ($service !== null) {
             $icingaKey .= "!$service";
         }

--- a/library/Jira/Web/Table/IssueDetails.php
+++ b/library/Jira/Web/Table/IssueDetails.php
@@ -36,8 +36,13 @@ class IssueDetails extends Table
         $fields = $issue->fields;
         $projectKey = $fields->project->key;
         $keyField = $config->get('key_fields', 'icingaKey', 'icingaKey');
-
-        $icingaKey = preg_replace('/^BEGIN(.+)END$/', '$1', $fields->$keyField);
+        $prefix = $config->get('key_fields', 'icingaKeyPrefix','');
+        $pattern = '/^BEGIN(.+)END$/';
+        if($prefix !== ''){
+            $pattern = '/^BEGIN_' . $prefix . '_(.+)END$/';
+        }
+        
+        $icingaKey = preg_replace($pattern, '$1', $fields->$keyField);
         $parts = explode('!', $icingaKey);
         $host = array_shift($parts);
         $helper->setHostName($host);


### PR DESCRIPTION
* Introduces a Prefix for the icingaKey
* encloses the $keyfield so Jira Fields with spaces can be used as icingaKey.

This will not break with existing jira tickets if the prefix is not set at all.

Of course if the prefix is set older tickets can not be found.

Best Regards
Nicolas