### PR TITLE
Support PHP 8.5

### DIFF
--- a/application/forms/Config/FieldConfigForm.php
+++ b/application/forms/Config/FieldConfigForm.php
@@ -382,7 +382,7 @@ class FieldConfigForm extends CompatForm
             $nullLabel = $this->translate('- please choose -');
         }
 
-        return [null => $nullLabel] + $enum;
+        return ['' => $nullLabel] + $enum;
     }
 
     public function onSuccess()

--- a/library/Jira/Web/Form/NewIssueForm.php
+++ b/library/Jira/Web/Form/NewIssueForm.php
@@ -193,7 +193,7 @@ class NewIssueForm extends CompatForm
             $nullLabel = $this->translate('- please choose -');
         }
 
-        return [null => $nullLabel] + $enum;
+        return ['' => $nullLabel] + $enum;
     }
 
     private function enumTemplates()


### PR DESCRIPTION
## Changes made:
### PHP 8.5:
- [Using null as an array offset is deprecated.](https://www.php.net/manual/en/migration85.deprecated.php#migration85.deprecated.core.using-null-as-an-array-offset)

No changes are required for PHP8.4 support.

resolves #158 