### PR TITLE
Change 'project' endpoint to 'project/search' for cloud deployments

### DIFF
--- a/library/Jira/Web/Form/NewIssueForm.php
+++ b/library/Jira/Web/Form/NewIssueForm.php
@@ -49,8 +49,14 @@ class NewIssueForm extends CompatForm
         $defaultTemplate = $config->get('ui', 'default_template');
         $defaultAck = $config->get('ui', 'acknowledge', 'y');
 
+        if (strtolower($this->jira->getServerInfo()->deploymentType) === 'cloud') {
+            $projects = $this->jira->get('project/search')->getResult()->values;
+        } else {
+            $projects = $this->jira->get('project')->getResult();
+        }
+
         $enum = $this->makeEnum(
-            $this->jira->get('project')->getResult(),
+            $projects,
             'key',
             'name'
         );

--- a/library/Jira/Web/Form/TemplateForm.php
+++ b/library/Jira/Web/Form/TemplateForm.php
@@ -29,7 +29,11 @@ class TemplateForm extends BaseHtmlElement
     protected function assemble()
     {
         try {
-            $projects = $this->jira->get('project')->getResult();
+            if (strtolower($this->jira->getServerInfo()->deploymentType) === 'cloud') {
+                $projects = $this->jira->get('project/search')->getResult()->values;
+            } else {
+                $projects = $this->jira->get('project')->getResult();
+            }
         } catch (Exception $e) {
             $this->add(Html::tag('p', ['class' => 'state-hint error'], sprintf(
                 $this->translate('Unable to talk to Jira, please check your configuration: %s'),


### PR DESCRIPTION
The 'project' endpoint has been deprecated for Jira Cloud, check the [Jira cloud documentation](https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-projects/#api-rest-api-2-project-get)